### PR TITLE
Update Antinuke

### DIFF
--- a/Antinuke?.js
+++ b/Antinuke?.js
@@ -1,7 +1,12 @@
-client.on('guildMemberAdd', member =>{
-  if(member.user.bot) {
-    member.ban({ days: 7, reason: 'wuds antinuke xd LOL' })
-    .then(console.log)
-    .catch(console.error);
-  }
+client.on('guildMemberAdd', member => {
+    let whitelisted = ["155149108183695360", "159985870458322944"] // Dyno and MEE6
+    if (member.user.bot) {
+        if (whitelisted.includes(member.user.id)) return;
+        member.ban({
+                days: 7,
+                reason: 'wuds antinuke xd LOL'
+            })
+            .then(console.log)
+            .catch(console.error);
+    }
 });


### PR DESCRIPTION
adds an ability to whitelist certain bots from being banned if they are normally used to ban people. example ids include dyno and mee6